### PR TITLE
Add GitHub Actions badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Foreman MCP Server
 
+[![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Pylint](https://github.com/InfraMCP/foreman-mcp-server/actions/workflows/pylint.yml/badge.svg)](https://github.com/InfraMCP/foreman-mcp-server/actions/workflows/pylint.yml)
+[![Safety Security Scan](https://github.com/InfraMCP/foreman-mcp-server/actions/workflows/safety-scan.yml/badge.svg)](https://github.com/InfraMCP/foreman-mcp-server/actions/workflows/safety-scan.yml)
+[![Dependency Security Check](https://github.com/InfraMCP/foreman-mcp-server/actions/workflows/dependency-security.yml/badge.svg)](https://github.com/InfraMCP/foreman-mcp-server/actions/workflows/dependency-security.yml)
+
 MCP server for Foreman host management and infrastructure automation.
 
 ## Features


### PR DESCRIPTION
## Add GitHub Actions Badges to README

This PR adds the missing GitHub Actions badges to the Foreman MCP Server README to match InfraMCP organization standards.

### Added Badges
- **Python 3.10+**: Shows supported Python version
- **MIT License**: License information
- **Pylint**: Code quality status from GitHub Actions
- **Safety Security Scan**: Security vulnerability scanning status
- **Dependency Security Check**: Dependency security scanning status

### Benefits
- **Professional presentation**: Consistent with other InfraMCP projects
- **Quality visibility**: Users can see code quality and security status at a glance
- **Organization standards**: Follows established InfraMCP documentation patterns
- **Trust indicators**: Shows active maintenance and security practices

This brings the Foreman MCP Server documentation in line with the phpIPAM, SSH, Win, vSphere, and Atlassian MCP servers.